### PR TITLE
Remove the custom filtering

### DIFF
--- a/autoload/asyncomplete/sources/omni.vim
+++ b/autoload/asyncomplete/sources/omni.vim
@@ -24,42 +24,9 @@ function! asyncomplete#sources#omni#completor(opt, ctx) abort
     let l:startcol = l:col
   endif
 
-  let omnifunc_matches = Omnifunc_ref(0, l:typed[l:startcol:l:col])
-  let l:matches = map(copy(omnifunc_matches), function('s:convert_omnifunc_result'))
+  let l:matches = Omnifunc_ref(0, l:typed[l:startcol:l:col])
 
   call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol + 1, l:matches)
-endfunction
-
-function! s:convert_omnifunc_result(_, match) abort
-  let width = &columns
-
-  " 'word' is inserted when it's selected
-  let word = ''
-  " 'abbr' is showen instead of 'word'
-  let abbr = ''
-  if type(a:match) == type({})
-    let word = s:trim(a:match["word"], width)
-    let abbr = s:trim(get(a:match, "abbr", ""), width)
-  else
-    let word = s:trim(a:match, width)
-  endif
-
-  let completion_item = {"word": word, "dup": 0, "icase": 1, "menu": "[omni]"}
-  if abbr !=# ''
-    let completion_item["abbr"] = abbr
-  endif
-
-  return completion_item
-endfunction
-
-function! s:trim(word, length) abort
-  let ellipsis = '...'
-  let ellipsis_length = strwidth(ellipsis)
-  if strwidth(a:word) + ellipsis_length > a:length
-    return a:word[0:(a:length - ellipsis_length)].ellipsis
-  else
-    return a:word
-  endif
 endfunction
 
 


### PR DESCRIPTION
Just noticing here that if you pass the Omnifunc matches directly into `asyncomplete#complete`, you don't need any filtering. This is beneficial on omnifuncs like vim-javacomplete2 that provide a lot of additional information beyond word and abbr

I'd also be happy to convert this into an option that can be set - perhaps `g:asyncomplete_omni_filtering_enabled`?

Also, of course, feel free to shut this PR down if you don't want any of this :)